### PR TITLE
App <> chain connections, speedrun

### DIFF
--- a/app/api/urls.py
+++ b/app/api/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
   # Settlement
   path('settle/<int:group_id>/debts/', settlement_views.debts, name='settle-debts'),
   path('settle/<int:group_id>/initiate/', settlement_views.initiate, name='settle-initiate'),
+  path('settle/for-user/', settlement_views.settle_for_user, name='settle-for-user'),
   path('settle/status/<str:tx_hash>/', settlement_views.status, name='settle-status'),
 
   # Activity

--- a/app/api/utils/hasura_client.py
+++ b/app/api/utils/hasura_client.py
@@ -1,0 +1,244 @@
+"""
+Hasura GraphQL client for khaaliSplit.
+
+Queries the Envio HyperIndex data via Hasura's GraphQL endpoint.
+Degrades gracefully if Hasura is not reachable or the envio schema
+is not tracked yet.
+
+The indexer writes to the 'envio' schema in khaalisplit_db.
+Hasura exposes this via GraphQL at HASURA_URL/v1/graphql.
+"""
+import json
+import logging
+import urllib.request
+import urllib.error
+
+from django.conf import settings
+
+logger = logging.getLogger('wide_event')
+
+
+class HasuraError(Exception):
+  """Raised when Hasura returns an error or is unreachable."""
+  pass
+
+
+def _hasura_url() -> str:
+  """Get Hasura GraphQL endpoint URL."""
+  return getattr(settings, 'HASURA_GRAPHQL_URL', '') or 'http://kdio_hasura:8080/v1/graphql'
+
+
+def _admin_secret() -> str:
+  """Get Hasura admin secret for auth."""
+  return getattr(settings, 'HASURA_ADMIN_SECRET', '')
+
+
+def graphql_query(query: str, variables: dict | None = None) -> dict:
+  """
+  Execute a GraphQL query against Hasura.
+
+  Args:
+    query: GraphQL query string
+    variables: Optional variables dict
+
+  Returns:
+    The 'data' portion of the response
+
+  Raises:
+    HasuraError: If the request fails or returns errors
+  """
+  url = _hasura_url()
+  if not url:
+    raise HasuraError('HASURA_GRAPHQL_URL not configured')
+
+  headers = {
+    'Content-Type': 'application/json',
+  }
+  secret = _admin_secret()
+  if secret:
+    headers['x-hasura-admin-secret'] = secret
+
+  body = {'query': query}
+  if variables:
+    body['variables'] = variables
+
+  data = json.dumps(body).encode('utf-8')
+  req = urllib.request.Request(url, data=data, headers=headers, method='POST')
+
+  try:
+    with urllib.request.urlopen(req, timeout=10) as resp:
+      result = json.loads(resp.read().decode('utf-8'))
+
+    if 'errors' in result:
+      error_msg = result['errors'][0].get('message', 'Unknown GraphQL error')
+      logger.warning(f'Hasura GraphQL error: {error_msg}')
+      raise HasuraError(error_msg)
+
+    return result.get('data', {})
+
+  except urllib.error.URLError as e:
+    logger.debug(f'Hasura not reachable: {e.reason}')
+    raise HasuraError(f'Hasura connection failed: {e.reason}') from e
+  except urllib.error.HTTPError as e:
+    error_body = e.read().decode('utf-8', errors='replace')
+    logger.warning(f'Hasura HTTP error: {e.code} {error_body}')
+    raise HasuraError(f'Hasura returned {e.code}') from e
+
+
+def is_available() -> bool:
+  """Check if Hasura is reachable and the envio schema is queryable."""
+  try:
+    graphql_query('{ __typename }')
+    return True
+  except (HasuraError, Exception):
+    return False
+
+
+# ─── Convenience query functions ──────────────────────────────────────────────
+
+def get_friend_requests(user_address: str) -> list:
+  """Get friend requests for a user address from the indexer."""
+  try:
+    query = '''
+      query FriendRequests($user: String!) {
+        FriendRequest(where: {user: {_eq: $user}}) {
+          id
+          user
+          friend
+          status
+          timestamp
+        }
+      }
+    '''
+    data = graphql_query(query, {'user': user_address.lower()})
+    return data.get('FriendRequest', [])
+  except HasuraError:
+    return []
+
+
+def get_user_groups(user_address: str) -> list:
+  """Get groups a user belongs to from the indexer."""
+  try:
+    query = '''
+      query UserGroups($member: String!) {
+        GroupMember(where: {member: {_eq: $member}, status: {_eq: "accepted"}}) {
+          id
+          groupId
+          member
+          group {
+            id
+            groupId
+            nameHash
+            creator
+            memberCount
+          }
+        }
+      }
+    '''
+    data = graphql_query(query, {'member': user_address.lower()})
+    return data.get('GroupMember', [])
+  except HasuraError:
+    return []
+
+
+def get_group_expenses(group_id: int) -> list:
+  """Get expenses for a group from the indexer."""
+  try:
+    query = '''
+      query GroupExpenses($groupId: numeric!) {
+        Expense(where: {groupId: {_eq: $groupId}}, order_by: {timestamp: desc}) {
+          id
+          expenseId
+          creator
+          groupId
+          dataHash
+          encryptedData
+          timestamp
+        }
+      }
+    '''
+    data = graphql_query(query, {'groupId': group_id})
+    return data.get('Expense', [])
+  except HasuraError:
+    return []
+
+
+def get_settlements(user_address: str) -> list:
+  """Get settlements involving a user address from the indexer."""
+  try:
+    query = '''
+      query UserSettlements($address: String!) {
+        Settlement(
+          where: {_or: [
+            {sender: {_eq: $address}},
+            {recipientNode: {_eq: $address}}
+          ]},
+          order_by: {timestamp: desc},
+          limit: 50
+        ) {
+          id
+          sender
+          recipientNode
+          amount
+          token
+          sourceChain
+          destChain
+          txHash
+          timestamp
+          status
+        }
+      }
+    '''
+    data = graphql_query(query, {'address': user_address.lower()})
+    return data.get('Settlement', [])
+  except HasuraError:
+    return []
+
+
+def get_settlement_by_tx(tx_hash: str) -> dict | None:
+  """Get a specific settlement by transaction hash."""
+  try:
+    query = '''
+      query SettlementByTx($txHash: String!) {
+        Settlement(where: {txHash: {_eq: $txHash}}, limit: 1) {
+          id
+          sender
+          recipientNode
+          amount
+          token
+          sourceChain
+          destChain
+          txHash
+          timestamp
+          status
+        }
+      }
+    '''
+    data = graphql_query(query, {'txHash': tx_hash})
+    settlements = data.get('Settlement', [])
+    return settlements[0] if settlements else None
+  except HasuraError:
+    return None
+
+
+def get_subname_records(node: str) -> dict:
+  """Get ENS text and addr records for a subname node."""
+  try:
+    query = '''
+      query SubnameRecords($node: String!) {
+        TextRecord(where: {node: {_eq: $node}}) {
+          key
+          value
+        }
+        AddrRecord(where: {node: {_eq: $node}}, limit: 1) {
+          addr
+        }
+      }
+    '''
+    data = graphql_query(query, {'node': node})
+    text_records = {r['key']: r['value'] for r in data.get('TextRecord', [])}
+    addr_records = data.get('AddrRecord', [])
+    addr = addr_records[0]['addr'] if addr_records else ''
+    return {'text': text_records, 'addr': addr}
+  except HasuraError:
+    return {'text': {}, 'addr': ''}

--- a/app/api/utils/web3_utils.py
+++ b/app/api/utils/web3_utils.py
@@ -124,6 +124,40 @@ FRIENDS_ABI = [
     'stateMutability': 'view',
     'type': 'function',
   },
+  # ── Relay (backend-only) ──
+  # requestFriendFor(address user, address friend)
+  {
+    'inputs': [
+      {'name': 'user', 'type': 'address'},
+      {'name': 'friend', 'type': 'address'},
+    ],
+    'name': 'requestFriendFor',
+    'outputs': [],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+  },
+  # acceptFriendFor(address user, address requester)
+  {
+    'inputs': [
+      {'name': 'user', 'type': 'address'},
+      {'name': 'requester', 'type': 'address'},
+    ],
+    'name': 'acceptFriendFor',
+    'outputs': [],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+  },
+  # removeFriendFor(address user, address friend)
+  {
+    'inputs': [
+      {'name': 'user', 'type': 'address'},
+      {'name': 'friend', 'type': 'address'},
+    ],
+    'name': 'removeFriendFor',
+    'outputs': [],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+  },
 ]
 
 GROUPS_ABI = [
@@ -174,6 +208,54 @@ GROUPS_ABI = [
     'stateMutability': 'view',
     'type': 'function',
   },
+  # ── Relay (backend-only) ──
+  # createGroupFor(address user, bytes32 nameHash, bytes encryptedKey) → uint256
+  {
+    'inputs': [
+      {'name': 'user', 'type': 'address'},
+      {'name': 'nameHash', 'type': 'bytes32'},
+      {'name': 'encryptedKey', 'type': 'bytes'},
+    ],
+    'name': 'createGroupFor',
+    'outputs': [{'name': 'groupId', 'type': 'uint256'}],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+  },
+  # inviteMemberFor(address inviter, uint256 groupId, address member, bytes encryptedKey)
+  {
+    'inputs': [
+      {'name': 'inviter', 'type': 'address'},
+      {'name': 'groupId', 'type': 'uint256'},
+      {'name': 'member', 'type': 'address'},
+      {'name': 'encryptedKey', 'type': 'bytes'},
+    ],
+    'name': 'inviteMemberFor',
+    'outputs': [],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+  },
+  # acceptGroupInviteFor(address user, uint256 groupId)
+  {
+    'inputs': [
+      {'name': 'user', 'type': 'address'},
+      {'name': 'groupId', 'type': 'uint256'},
+    ],
+    'name': 'acceptGroupInviteFor',
+    'outputs': [],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+  },
+  # leaveGroupFor(address user, uint256 groupId)
+  {
+    'inputs': [
+      {'name': 'user', 'type': 'address'},
+      {'name': 'groupId', 'type': 'uint256'},
+    ],
+    'name': 'leaveGroupFor',
+    'outputs': [],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+  },
 ]
 
 EXPENSES_ABI = [
@@ -197,6 +279,33 @@ EXPENSES_ABI = [
       {'name': 'newEncryptedData', 'type': 'bytes'},
     ],
     'name': 'updateExpense',
+    'outputs': [],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+  },
+  # ── Relay (backend-only) ──
+  # addExpenseFor(address creator, uint256 groupId, bytes32 dataHash, bytes encryptedData) → uint256
+  {
+    'inputs': [
+      {'name': 'creator', 'type': 'address'},
+      {'name': 'groupId', 'type': 'uint256'},
+      {'name': 'dataHash', 'type': 'bytes32'},
+      {'name': 'encryptedData', 'type': 'bytes'},
+    ],
+    'name': 'addExpenseFor',
+    'outputs': [{'name': 'expenseId', 'type': 'uint256'}],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+  },
+  # updateExpenseFor(address creator, uint256 expenseId, bytes32 newDataHash, bytes newEncryptedData)
+  {
+    'inputs': [
+      {'name': 'creator', 'type': 'address'},
+      {'name': 'expenseId', 'type': 'uint256'},
+      {'name': 'newDataHash', 'type': 'bytes32'},
+      {'name': 'newEncryptedData', 'type': 'bytes'},
+    ],
+    'name': 'updateExpenseFor',
     'outputs': [],
     'stateMutability': 'nonpayable',
     'type': 'function',

--- a/app/api/views/settlement.py
+++ b/app/api/views/settlement.py
@@ -1,5 +1,6 @@
 """
-Settlement views — debt summary, initiation, and status polling.
+Settlement views — debt summary, initiation, status polling, and
+settle-for-user endpoints (authorization + gateway flows).
 """
 import json
 import logging
@@ -8,6 +9,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_GET, require_POST
+from web3 import Web3
 
 from api.models import (
   Activity,
@@ -19,6 +21,8 @@ from api.models import (
   User,
 )
 from api.utils.debt_simplifier import compute_group_debts
+from api.utils.ens_codec import subname_node
+from api.utils.web3_utils import send_tx
 
 logger = logging.getLogger('wide_event')
 
@@ -142,6 +146,171 @@ def initiate(request, group_id):
     'tx_hash': tx_hash,
     'settlement_status': settlement.status,
   })
+
+
+@login_required(login_url='/api/auth/login/')
+@require_POST
+def settle_for_user(request):
+  """
+  POST /api/settle/for-user/
+
+  Backend-relayed settlement. Accepts two types:
+  - type=authorization: ERC-3009 transferWithAuthorization flow
+    Requires: to_subname, amount, signature, auth_from, valid_after, valid_before, nonce
+  - type=gateway: Circle Gateway cross-chain flow
+    Requires: to_subname, amount, signed_burn_intent (JSON)
+
+  Both flows call the settlement contract via send_tx().
+  """
+  try:
+    data = json.loads(request.body)
+  except (json.JSONDecodeError, AttributeError):
+    data = request.POST.dict()
+
+  settle_type = data.get('type', 'authorization')
+  to_subname = data.get('to_subname', '')
+  amount_str = data.get('amount', '0')
+  source_chain = int(data.get('source_chain', 11155111))
+  dest_chain = int(data.get('dest_chain', 11155111))
+  group_id = data.get('group_id')
+
+  if not to_subname:
+    return JsonResponse({'error': 'Missing to_subname'}, status=400)
+
+  # Resolve recipient's ENS node
+  recipient_node = subname_node(to_subname)
+
+  # Get sender's address
+  primary_addr = request.user.addresses.filter(is_primary=True).first()
+  if not primary_addr:
+    return JsonResponse({'error': 'No linked wallet'}, status=400)
+  sender_address = Web3.to_checksum_address(primary_addr.address)
+
+  # Look up recipient user
+  try:
+    to_user = User.objects.get(subname=to_subname)
+  except User.DoesNotExist:
+    to_user = None
+
+  to_linked = to_user.addresses.filter(is_primary=True).first() if to_user else None
+  to_address = to_linked.address if to_linked else ''
+
+  # Look up group if provided
+  group = None
+  if group_id:
+    group = CachedGroup.objects.filter(group_id=int(group_id)).first()
+
+  tx_hash = None
+  memo = data.get('memo', '').encode('utf-8') if data.get('memo') else b''
+
+  if settle_type == 'authorization':
+    # ERC-3009 transferWithAuthorization flow
+    signature = data.get('signature', '')
+    auth_from = data.get('auth_from', sender_address)
+    valid_after = int(data.get('valid_after', 0))
+    valid_before = int(data.get('valid_before', 2**256 - 1))
+    nonce = data.get('nonce', '')
+
+    if not signature:
+      return JsonResponse({'error': 'Missing signature'}, status=400)
+
+    # Convert amount to USDC base units (6 decimals)
+    try:
+      amount_int = int(float(amount_str) * 1_000_000)
+    except (ValueError, TypeError):
+      return JsonResponse({'error': 'Invalid amount'}, status=400)
+
+    nonce_bytes = bytes.fromhex(nonce.replace('0x', '')) if nonce else b'\x00' * 32
+    sig_bytes = bytes.fromhex(signature.replace('0x', ''))
+
+    auth_tuple = (
+      Web3.to_checksum_address(auth_from),
+      valid_after,
+      valid_before,
+      nonce_bytes,
+    )
+
+    try:
+      tx_hash = send_tx(
+        'settlement', 'settleWithAuthorization',
+        recipient_node,
+        amount_int,
+        memo,
+        auth_tuple,
+        sig_bytes,
+        chain_id=source_chain,
+        gas=500_000,
+      )
+      logger.info(f'settleWithAuthorization tx={tx_hash}')
+    except Exception as e:
+      logger.exception('settleWithAuthorization failed')
+      return JsonResponse({'error': f'On-chain settlement failed: {e}'}, status=500)
+
+  elif settle_type == 'gateway':
+    # Circle Gateway cross-chain flow
+    from api.utils.circle_gateway import get_gateway_attestation
+
+    signed_burn_intent = data.get('signed_burn_intent', {})
+    if not signed_burn_intent:
+      return JsonResponse({'error': 'Missing signed_burn_intent'}, status=400)
+
+    try:
+      attestation_data = get_gateway_attestation(signed_burn_intent)
+      attestation_bytes = bytes.fromhex(attestation_data['attestation'].replace('0x', ''))
+      attestation_sig = bytes.fromhex(attestation_data['signature'].replace('0x', ''))
+
+      tx_hash = send_tx(
+        'settlement', 'settleFromGateway',
+        attestation_bytes,
+        attestation_sig,
+        recipient_node,
+        sender_address,
+        memo,
+        chain_id=dest_chain,
+        gas=500_000,
+      )
+      logger.info(f'settleFromGateway tx={tx_hash}')
+    except Exception as e:
+      logger.exception('settleFromGateway failed')
+      return JsonResponse({'error': f'Gateway settlement failed: {e}'}, status=500)
+
+  else:
+    return JsonResponse({'error': f'Unknown type: {settle_type}'}, status=400)
+
+  # Record settlement in DB
+  if tx_hash:
+    settlement = CachedSettlement.objects.create(
+      tx_hash=tx_hash,
+      from_user=request.user,
+      from_address=sender_address,
+      to_address=to_address,
+      to_user=to_user,
+      token='usdc',
+      amount=amount_str,
+      source_chain=source_chain,
+      dest_chain=dest_chain,
+      status=CachedSettlement.Status.SUBMITTED,
+      group=group,
+    )
+
+    Activity.objects.create(
+      user=request.user,
+      action_type=Activity.ActionType.SETTLEMENT_INITIATED,
+      group_id=group.group_id if group else None,
+      settlement_hash=tx_hash,
+      message=f'Settled {amount_str} USDC to {to_subname}',
+    )
+
+    request._wide_event['extra']['settlement_tx'] = tx_hash
+
+    return JsonResponse({
+      'status': 'ok',
+      'tx_hash': tx_hash,
+      'settlement_status': settlement.status,
+      'type': settle_type,
+    })
+
+  return JsonResponse({'error': 'Settlement failed'}, status=500)
 
 
 @login_required(login_url='/api/auth/login/')

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -187,3 +187,7 @@ CIRCLE_API_KEY = os.getenv('CIRCLE_API_KEY', '')
 CIRCLE_GATEWAY_URL = os.getenv(
   'CIRCLE_GATEWAY_URL', 'https://gateway-api-testnet.circle.com'
 )
+
+# Hasura / Envio Indexer
+HASURA_GRAPHQL_URL = os.getenv('HASURA_GRAPHQL_URL', 'http://kdio_hasura:8080/v1/graphql')
+HASURA_ADMIN_SECRET = os.getenv('HASURA_ADMIN_SECRET', '')

--- a/app/static/js/keystore.js
+++ b/app/static/js/keystore.js
@@ -1,0 +1,181 @@
+/**
+ * keystore.js — IndexedDB key storage for khaaliSplit
+ *
+ * Stores ECDH shared secrets and group symmetric keys in IndexedDB
+ * so users don't need to re-derive them every session.
+ *
+ * Exposed globally as `window.khaaliKeystore`.
+ */
+(function () {
+  'use strict';
+
+  const DB_NAME = 'khaaliSplit-keystore';
+  const DB_VERSION = 1;
+  const STORE_NAME = 'keys';
+
+  let db = null;
+
+  /**
+   * Open (or create) the IndexedDB database.
+   * @returns {Promise<IDBDatabase>}
+   */
+  function openDB() {
+    if (db) return Promise.resolve(db);
+
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+      request.onupgradeneeded = (event) => {
+        const database = event.target.result;
+        if (!database.objectStoreNames.contains(STORE_NAME)) {
+          database.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        }
+      };
+
+      request.onsuccess = (event) => {
+        db = event.target.result;
+        resolve(db);
+      };
+
+      request.onerror = (event) => {
+        console.error('[keystore] Failed to open DB:', event.target.error);
+        reject(event.target.error);
+      };
+    });
+  }
+
+  const khaaliKeystore = {
+
+    /**
+     * Store a group key.
+     * @param {number|string} groupId — on-chain group ID
+     * @param {string} keyHex — 64-char hex string (AES-256 key)
+     * @param {string} walletAddress — owner's wallet address
+     */
+    async storeGroupKey(groupId, keyHex, walletAddress) {
+      try {
+        const database = await openDB();
+        const tx = database.transaction(STORE_NAME, 'readwrite');
+        const store = tx.objectStore(STORE_NAME);
+        store.put({
+          id: `group:${groupId}:${walletAddress.toLowerCase()}`,
+          type: 'group_key',
+          groupId: String(groupId),
+          keyHex: keyHex,
+          walletAddress: walletAddress.toLowerCase(),
+          updatedAt: Date.now(),
+        });
+        await new Promise((resolve, reject) => {
+          tx.oncomplete = resolve;
+          tx.onerror = () => reject(tx.error);
+        });
+        console.log('[keystore] Stored group key for group', groupId);
+      } catch (err) {
+        console.error('[keystore] Failed to store group key:', err);
+      }
+    },
+
+    /**
+     * Retrieve a group key.
+     * @param {number|string} groupId
+     * @param {string} walletAddress
+     * @returns {Promise<string|null>} — key hex or null
+     */
+    async getGroupKey(groupId, walletAddress) {
+      try {
+        const database = await openDB();
+        const tx = database.transaction(STORE_NAME, 'readonly');
+        const store = tx.objectStore(STORE_NAME);
+        const id = `group:${groupId}:${walletAddress.toLowerCase()}`;
+
+        return new Promise((resolve, reject) => {
+          const request = store.get(id);
+          request.onsuccess = () => {
+            const result = request.result;
+            resolve(result ? result.keyHex : null);
+          };
+          request.onerror = () => reject(request.error);
+        });
+      } catch (err) {
+        console.error('[keystore] Failed to get group key:', err);
+        return null;
+      }
+    },
+
+    /**
+     * Store a shared secret with another user.
+     * @param {string} theirAddress — the other user's wallet address
+     * @param {string} secretHex — shared secret hex
+     * @param {string} myAddress — our wallet address
+     */
+    async storeSharedSecret(theirAddress, secretHex, myAddress) {
+      try {
+        const database = await openDB();
+        const tx = database.transaction(STORE_NAME, 'readwrite');
+        const store = tx.objectStore(STORE_NAME);
+        store.put({
+          id: `shared:${myAddress.toLowerCase()}:${theirAddress.toLowerCase()}`,
+          type: 'shared_secret',
+          theirAddress: theirAddress.toLowerCase(),
+          myAddress: myAddress.toLowerCase(),
+          secretHex: secretHex,
+          updatedAt: Date.now(),
+        });
+        await new Promise((resolve, reject) => {
+          tx.oncomplete = resolve;
+          tx.onerror = () => reject(tx.error);
+        });
+      } catch (err) {
+        console.error('[keystore] Failed to store shared secret:', err);
+      }
+    },
+
+    /**
+     * Retrieve a shared secret.
+     * @param {string} theirAddress
+     * @param {string} myAddress
+     * @returns {Promise<string|null>}
+     */
+    async getSharedSecret(theirAddress, myAddress) {
+      try {
+        const database = await openDB();
+        const tx = database.transaction(STORE_NAME, 'readonly');
+        const store = tx.objectStore(STORE_NAME);
+        const id = `shared:${myAddress.toLowerCase()}:${theirAddress.toLowerCase()}`;
+
+        return new Promise((resolve, reject) => {
+          const request = store.get(id);
+          request.onsuccess = () => {
+            const result = request.result;
+            resolve(result ? result.secretHex : null);
+          };
+          request.onerror = () => reject(request.error);
+        });
+      } catch (err) {
+        console.error('[keystore] Failed to get shared secret:', err);
+        return null;
+      }
+    },
+
+    /**
+     * Delete all stored keys (logout cleanup).
+     */
+    async clearAll() {
+      try {
+        const database = await openDB();
+        const tx = database.transaction(STORE_NAME, 'readwrite');
+        const store = tx.objectStore(STORE_NAME);
+        store.clear();
+        await new Promise((resolve, reject) => {
+          tx.oncomplete = resolve;
+          tx.onerror = () => reject(tx.error);
+        });
+        console.log('[keystore] Cleared all keys');
+      } catch (err) {
+        console.error('[keystore] Failed to clear:', err);
+      }
+    },
+  };
+
+  window.khaaliKeystore = khaaliKeystore;
+})();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -67,6 +67,7 @@
     {% include 'prisms/bottom-nav.html' %}
 
     <script src="{% static 'js/crypto.js' %}" defer></script>
+    <script src="{% static 'js/keystore.js' %}" defer></script>
     <script src="{% static 'js/wallet.js' %}" defer></script>
     <script src="{% static 'js/app.js' %}" defer></script>
 

--- a/app/templates/pages/onboarding-wallet.html
+++ b/app/templates/pages/onboarding-wallet.html
@@ -26,6 +26,23 @@
   </div>
   {% else %}
 
+  {# Mobile-specific messaging #}
+  <div id="mobile-msg" class="hidden p-4 border border-border rounded-md text-center space-y-3"
+    _="on load if window.isMobile() remove .hidden from me end">
+    <p class="text-sm text-muted">
+      On mobile? Open this page in your
+      <strong class="text-foreground">MetaMask browser</strong>
+      for the best experience.
+    </p>
+    <button
+      class="w-full py-2.5 bg-foreground text-background font-medium rounded-md
+             hover:bg-foreground/90 transition-colors cursor-pointer"
+      _="on click call window.openMetaMaskDeepLink() end"
+    >
+      Open in MetaMask
+    </button>
+  </div>
+
   <div id="wallet-connect-area" class="space-y-4">
 
     {# Connect wallet button #}

--- a/app/templates/partials/debt_summary.html
+++ b/app/templates/partials/debt_summary.html
@@ -23,24 +23,28 @@
                      bg-foreground text-background hover:bg-foreground/90 px-3 py-1.5 text-xs"
               _="on click
                    if not window.walletConnected
-                     call window.showToast('Connect wallet first', 'error')
-                     halt
+                     call window.connectWallet()
+                     if not window.walletConnected
+                       halt
+                     end
                    end
                    set me.textContent to 'Signing...'
                    set me.disabled to true
                    try
-                     set result to await window.settleWithPermit(
-                       '{{ debt.to_address }}',
+                     set result to await window.initiateSettlement(
+                       '{{ debt.to_subname }}',
                        '{{ debt.amount }}',
-                       {{ group.group_id }}
+                       {{ group.group_id }},
+                       'authorization'
                      )
-                     if result and result.hash
-                       call window.showToast('Settlement submitted!', 'success')
+                     if result and result.tx_hash
                        set target to closest <div/> to me
-                       set target.innerHTML to '<p class=\"text-sm text-muted\">Tx: ' + result.hash.substring(0, 14) + '...</p>'
+                       set target.innerHTML to '<p class=\"text-sm text-emphasis\">Submitted! Tx: ' + result.tx_hash.substring(0, 14) + '...</p>'
+                     else
+                       set me.textContent to 'Pay'
+                       set me.disabled to false
                      end
                    catch e
-                     call window.showToast('Settlement failed: ' + e.message, 'error')
                      set me.textContent to 'Pay'
                      set me.disabled to false
                    end


### PR DESCRIPTION
Speed run remaining fixes. @claude ran pretty much independently for almost 70 minutes!

<details>

  <summary>@claude knows what's really changed,</summary>

<h2>Summary</h2>
<ul>
<li><strong>Fix wallet linking bug</strong>: <code>is_primary</code> was being overwritten to <code>False</code> on re-verification due to <code>update_or_create</code> recalculating defaults. Now preserves existing <code>is_primary=True</code> and normalizes addresses to checksummed format with case-insensitive lookups.</li>
<li><strong>Wire social graph to on-chain relay functions (Session 3)</strong>: Friends, groups, and expenses views now call <code>*For</code> relay ABIs (<code>requestFriendFor</code>, <code>createGroupFor</code>, <code>addExpenseFor</code>, etc.) via <code>send_tx()</code>. All on-chain calls are non-blocking (try/except) so UI operations succeed even if chain calls fail.</li>
<li><strong>Fix ECDH encryption</strong>: Replaced broken one-directional key derivation with proper <code>ethers.SigningKey.computeSharedSecret()</code>. Added deterministic ECDH key pair derivation from wallet signature, HKDF key derivation, and AES-256-GCM wrapping.</li>
<li><strong>Add IndexedDB keystore</strong>: New <code>keystore.js</code> stores group symmetric keys and ECDH shared secrets client-side so users don't re-derive every session.</li>
<li><strong>Wire settlement flow (Session 4)</strong>: New <code>settle_for_user</code> endpoint supporting ERC-3009 <code>transferWithAuthorization</code> and Circle Gateway cross-chain flows. Added <code>signSettlementAuthorization()</code> (EIP-712 typed data) and <code>initiateSettlement()</code> to wallet.js. Fixed <code>debt_summary.html</code> Pay button which was calling the removed <code>settleWithPermit()</code>.</li>
<li><strong>Integrate Envio/Hasura indexer (Session 5)</strong>: New <code>hasura_client.py</code> GraphQL client with convenience queries for friend requests, groups, expenses, settlements, and ENS subname records. ENS gateway now checks Hasura first for <code>com.khaalisplit.payment.*</code> text records before falling back to local DB.</li>
<li><strong>Add mobile MetaMask deep linking (Session 6)</strong>: Mobile detection via <code>isMobile()</code>, MetaMask in-app browser redirect, and mobile-specific messaging on the wallet onboarding page.</li>
</ul>
<h2>Files changed (17 files, +1312 / -73)</h2>

Area | Files
-- | --
Bug fix | api/views/auth.py
Relay ABIs | api/utils/web3_utils.py
Social graph | api/views/friends.py, api/views/groups.py, api/views/expenses.py
Settlement | api/views/settlement.py, api/urls.py
Indexer | api/utils/hasura_client.py (new), config/settings.py
ENS gateway | api/views/ens_gateway.py
Frontend JS | static/js/wallet.js, static/js/crypto.js, static/js/keystore.js (new)
Templates | templates/base.html, templates/partials/debt_summary.html, templates/pages/onboarding-wallet.html
Plan notes | .plans/application-03.md


<h2>Architecture decisions</h2>
<ul>
<li><strong>Client signs, backend relays</strong>: Wallet.js never submits on-chain transactions. All chain writes go through Django backend using <code>send_tx()</code> with the <code>BACKEND_PRIVATE_KEY</code>.</li>
<li><strong>Non-blocking chain calls</strong>: Every <code>send_tx()</code> is wrapped in try/except so the Django view always returns a valid response even if the chain call fails.</li>
<li><strong>Graceful degradation</strong>: Hasura client returns empty results on error; ENS gateway falls back to local DB when indexer is unavailable.</li>
<li><strong>No new dependencies</strong>: Hasura client uses stdlib <code>urllib</code> to avoid adding packages.</li>
</ul>
<h2>Test plan</h2>
<ul>
<li>[ ] Verify wallet linking: connect wallet, disconnect, reconnect — <code>is_primary</code> should remain <code>True</code></li>
<li>[ ] Verify friend request sends on-chain relay tx via backend</li>
<li>[ ] Verify group creation generates encrypted key and relays to chain</li>
<li>[ ] Verify settlement flow: Pay button → EIP-712 sign → backend relay → tx hash returned</li>
<li>[ ] Verify ENS gateway resolves payment text records from Hasura when available</li>
<li>[ ] Verify mobile: onboarding page shows MetaMask deep link on mobile user agents</li>
<li>[ ] Verify <code>python -m py_compile</code> passes on all modified Python files</li>
</ul>
<hr></body></html>

</details>